### PR TITLE
chore: align prettier with editorconfig and yamlls

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 max_line_length = 100
-
-[*.{js,ts,svelte}]
 quote_type = single
+
+[*.{yaml,yml}]
+quote_type = double

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,4 @@
 {
-	"useTabs": true,
-	"singleQuote": true,
 	"trailingComma": "none",
 	"printWidth": 100,
 	"plugins": ["prettier-plugin-svelte", "prettier-plugin-tailwindcss"],

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 packages:
-  - '.'
+  - "."
 
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
I use yamlls which uses double quotes by default. I'm fine with that so I configure editorconfig to
make an exception for yaml files.
