### PR TITLE
refactor: remove signup

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -3,6 +3,10 @@
 	"mcpServers": {
 		"svelte": {
 			"url": "https://mcp.svelte.dev/mcp"
+		},
+		"better-auth": {
+			"url": "https://mcp.inkeep.com/better-auth/mcp",
+			"type": "http"
 		}
 	}
 }

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,6 +4,13 @@
 - **Package Manager**: pnpm
 - **Add-ons**: prettier, eslint, vitest, playwright, tailwindcss, sveltekit-adapter, devtools-json, drizzle, better-auth, mdsvex, storybook, mcp
 
+## Secrets & Environment Variables
+
+- **Infisical**: All commands that require secrets (including `dev`, `build`, `preview`, `test`, `test:e2e`, and `db:*`) must be run using Infisical to provide environment variables.
+  - Usage: `infisical run -- [command]`
+  - Example: `infisical run -- pnpm dev`
+  - Example: `infisical run -- pnpm test:e2e`
+
 ## Documentation
 
 - [ElevenLabs API Reference](https://elevenlabs.io/docs/api-reference/introduction)

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -9,6 +9,9 @@ export const auth = betterAuth({
 	baseURL: env.ORIGIN,
 	secret: env.BETTER_AUTH_SECRET,
 	database: drizzleAdapter(db, { provider: 'pg' }),
-	emailAndPassword: { enabled: true },
+	emailAndPassword: {
+		enabled: true,
+		disableSignUp: true
+	},
 	plugins: [sveltekitCookies(getRequestEvent)] // make sure this is the last plugin in the array
 });

--- a/src/routes/demo/better-auth/login/+page.server.ts
+++ b/src/routes/demo/better-auth/login/+page.server.ts
@@ -33,29 +33,5 @@ export const actions: Actions = {
 		}
 
 		return redirect(302, '/demo/better-auth');
-	},
-	signUpEmail: async (event) => {
-		const formData = await event.request.formData();
-		const email = formData.get('email')?.toString() ?? '';
-		const password = formData.get('password')?.toString() ?? '';
-		const name = formData.get('name')?.toString() ?? '';
-
-		try {
-			await auth.api.signUpEmail({
-				body: {
-					email,
-					password,
-					name,
-					callbackURL: '/auth/verification-success'
-				}
-			});
-		} catch (error) {
-			if (error instanceof APIError) {
-				return fail(400, { message: error.message || 'Registration failed' });
-			}
-			return fail(500, { message: 'Unexpected error' });
-		}
-
-		return redirect(302, '/demo/better-auth');
 	}
 };

--- a/src/routes/demo/better-auth/login/+page.svelte
+++ b/src/routes/demo/better-auth/login/+page.svelte
@@ -23,20 +23,8 @@
 			class="mt-1 rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none"
 		/>
 	</label>
-	<label>
-		Name (for registration)
-		<input
-			name="name"
-			class="mt-1 rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none"
-		/>
-	</label>
 	<button class="rounded-md bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700"
 		>Login</button
-	>
-	<button
-		formaction="?/signUpEmail"
-		class="rounded-md bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700"
-		>Register</button
 	>
 </form>
 <p class="text-red-500">{form?.message ?? ''}</p>


### PR DESCRIPTION
In the future we may use signup via invitation but I'm quite sure there will never be a self-signup,
so lets remove this feature for now.

As a side-quest I improved AI tooling for better-auth:
	* add better auth mcp server
	* remember to pass secrets via `infisical run --`
