### PR TITLE
refactor(seed): refresh user accounts from infisical secrets

### DIFF
--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -5,10 +5,11 @@ import { getDb } from "$lib/server/db";
 import { user } from "$lib/server/db/schema";
 
 function getUserAccounts(): Array<{ email: string; password: string }> {
-	const output = execSync("infisical secrets --path user-accounts --plain").toString();
+	const output = execSync("infisical secrets --path user-accounts --plain --silent").toString();
 	return output
 		.trim()
 		.split("\n")
+		.filter((line) => line.includes("="))
 		.map((line) => {
 			const eq = line.indexOf("=");
 			return { email: line.slice(0, eq), password: line.slice(eq + 1) };
@@ -37,9 +38,9 @@ const auth = betterAuth({
 	},
 });
 
-await db.delete(user);
-
 const accounts = getUserAccounts();
+
+await db.delete(user);
 for (const { email, password } of accounts) {
 	const name = email.split("@")[0];
 	await auth.api.signUpEmail({ body: { email, password, name } });

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -1,20 +1,30 @@
+import { execSync } from "node:child_process";
 import { betterAuth } from "better-auth/minimal";
 import { getAuth } from "$lib/server/auth";
 import { getDb } from "$lib/server/db";
+import { user } from "$lib/server/db/schema";
 
-function getSeedPassword(): string {
-	const password = process.env.SEED_USER_PASSWORD?.trim();
-
-	if (!password) {
-		throw new Error("SEED_USER_PASSWORD must be set before running db:seed.");
-	}
-
-	return password;
+function getUserAccounts(): Array<{ email: string; password: string }> {
+	const output = execSync("infisical secrets --path user-accounts --plain").toString();
+	return output
+		.trim()
+		.split("\n")
+		.map((line) => {
+			const eq = line.indexOf("=");
+			return { email: line.slice(0, eq), password: line.slice(eq + 1) };
+		});
 }
 
-const baseAuth = getAuth(getDb(), {
-	ORIGIN: "http://localhost:5173",
-	BETTER_AUTH_SECRET: "development-only-better-auth-secret",
+const db = getDb();
+
+const betterAuthSecret = process.env.BETTER_AUTH_SECRET;
+if (!betterAuthSecret) {
+	throw new Error("BETTER_AUTH_SECRET must be set. Run via: infisical run -- pnpm db:seed");
+}
+
+const baseAuth = getAuth(db, {
+	ORIGIN: process.env.ORIGIN ?? "http://localhost:5173",
+	BETTER_AUTH_SECRET: betterAuthSecret,
 });
 const auth = betterAuth({
 	...baseAuth.options,
@@ -27,10 +37,11 @@ const auth = betterAuth({
 	},
 });
 
-await auth.api.signUpEmail({
-	body: {
-		email: "user@example.org",
-		password: getSeedPassword(),
-		name: "John Doe",
-	},
-});
+await db.delete(user);
+
+const accounts = getUserAccounts();
+for (const { email, password } of accounts) {
+	const name = email.split("@")[0];
+	await auth.api.signUpEmail({ body: { email, password, name } });
+	console.log(`Created user: ${email}`);
+}


### PR DESCRIPTION
Replace the single hardcoded user with a dynamic seed that deletes all existing user accounts and re-creates one for each entry in the infisical `user-accounts` secret path.

- Read email/password pairs from `infisical secrets --path user-accounts --plain`
- Delete all rows in the `user` table before re-seeding (cascades to `session` and `account` via foreign key constraints)
- Create a user for each pair, deriving the display name from the email local part
- Require `BETTER_AUTH_SECRET` from the environment instead of using a hardcoded development value; throw a clear error if missing
- Use `process.env.ORIGIN` with a fallback to `http://localhost:5173`
- Intended to be run as: `infisical run -- pnpm db:seed`